### PR TITLE
Fix Cell-like citation labels for same author

### DIFF
--- a/example.tex
+++ b/example.tex
@@ -59,7 +59,7 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % bibtex
-\usepackage[backend=biber,natbib=true,style=authoryear,maxcitenames=2,maxbibnames=200,firstinits=true, uniquename=false,doi=false,isbn=false,url=false]{biblatex}
+\usepackage[backend=biber,natbib=true,style=authoryear,maxcitenames=2,maxbibnames=200,firstinits=true, uniquename=false,uniquelist=minyear,doi=false,isbn=false,url=false]{biblatex}
 \addbibresource{bibliothek.bib}
 \DefineBibliographyStrings{ngerman}{
  andothers = {{et\,al\adddot}}, 


### PR DESCRIPTION
When a first author occurs multiple times in a document, `biblatex` would try to disambiguate the citation label with more names, even though the publication year was different.